### PR TITLE
Use TypedTuple instead of Tuple 

### DIFF
--- a/examples/Examples.ipynb
+++ b/examples/Examples.ipynb
@@ -333,7 +333,7 @@
     "                '#00ffff', '#ff00ff', '#ffff00', '#ffffff']\n",
     "\n",
     "# Map the vertex colors into the 'color' slot of the faces\n",
-    "faces = [f + [None, [vertexcolors[i] for i in f]] for f in faces]\n",
+    "faces = [f + [None, [vertexcolors[i] for i in f], None] for f in faces]\n",
     "\n",
     "# Create the geometry:\n",
     "cubeGeometry = Geometry(vertices=vertices,\n",

--- a/js/scripts/prop-types.js
+++ b/js/scripts/prop-types.js
@@ -195,7 +195,8 @@ class ThreeTypeDict extends BaseType {
             const instances = this.typeName.map(function(typeName) {
                 return `        Instance(${typeName})`;
             });
-            return `Dict(Union([\n${instances.join(',\n')}\n    ]))${this.getTagString()}`;
+            return `Dict(Union([\n${
+                instances.join(',\n')}\n    ]))${this.getTagString()}`;
         }
         if (this.typeName === 'this') {
             return `Dict(This())${this.getTagString()}`;
@@ -224,7 +225,8 @@ class BufferMorphAttributes extends BaseType {
         const instances = typeNames.map(function(typeName) {
             return `        Instance(${typeName})`;
         });
-        return 'Dict(TypedTuple(Union([\n' + instances.join(',\n') + '\n    ])))' + this.getTagString();
+        return 'Dict(TypedTuple(Union([\n' +
+            instances.join(',\n') + '\n    ])))' + this.getTagString();
     }
     getPropArrayName() {
         return 'three_nested_properties';
@@ -241,7 +243,8 @@ class Bool extends BaseType {
     }
     getTraitlet() {
         const nullableStr = this.getNullableStr();
-        return `Bool(${this.getPythonDefaultValue()}, ${nullableStr})${this.getTagString()}`;
+        return `Bool(${this.getPythonDefaultValue()}, ${nullableStr})${
+            this.getTagString()}`;
     }
     getPropertyConverterFn() {
         return 'convertBool';
@@ -315,7 +318,9 @@ class Enum extends BaseType {
     }
     getTraitlet() {
         const nullableStr = this.getNullableStr();
-        return `Enum(${this.enumTypeName}, ${this.getPythonDefaultValue()}, ${nullableStr})${this.getTagString()}`;
+        return `Enum(${this.enumTypeName}, ${
+            this.getPythonDefaultValue()}, ${nullableStr})${
+            this.getTagString()}`;
     }
     getPropertyConverterFn() {
         return 'convertEnum';
@@ -329,7 +334,9 @@ class Color extends BaseType {
     }
     getTraitlet() {
         const nullableStr = this.getNullableStr();
-        return `Unicode(${this.getPythonDefaultValue()}, ${nullableStr})${this.getTagString()}`;
+        return `Unicode(${
+            this.getPythonDefaultValue()}, ${nullableStr})${
+            this.getTagString()}`;
     }
     getPropertyConverterFn() {
         return 'convertColor';
@@ -342,7 +349,8 @@ class ColorArray extends BaseType {
         this.defaultValue = defaultValue || ['#ffffff'];
     }
     getTraitlet() {
-        return `List(trait=Unicode(), default_value=${this.getPythonDefaultValue()})${this.getTagString()}`;
+        return `List(trait=Unicode(), default_value=${
+            this.getPythonDefaultValue()})${this.getTagString()}`;
     }
     getPropertyConverterFn() {
         return 'convertColorArray';
@@ -400,7 +408,9 @@ class DictType extends BaseType {
     }
     getTraitlet() {
         const nullableStr = this.getNullableStr();
-        return `Dict(default_value=${this.getPythonDefaultValue()}, ${nullableStr})${this.getTagString()}`;
+        return `Dict(default_value=${
+            this.getPythonDefaultValue()}, ${nullableStr})${
+            this.getTagString()}`;
     }
     getPropertyAssignmentFn() {
         return 'assignDict';
@@ -419,7 +429,8 @@ class FunctionType extends BaseType {
         this.defaultValue = fn || function() {};
     }
     getTraitlet() {
-        return `Unicode('${this.defaultValue.toString()}')${this.getTagString()}`;
+        return `Unicode('${
+            this.defaultValue.toString()}')${this.getTagString()}`;
     }
     getJSPropertyValue() {
         return this.defaultValue.toString();
@@ -435,7 +446,8 @@ class Vector2 extends BaseType {
         this.defaultValue = [ x||0, y||0 ];
     }
     getTraitlet() {
-        return `Vector2(default_value=${JSON.stringify(this.defaultValue)})${this.getTagString()}`;
+        return `Vector2(default_value=${
+            JSON.stringify(this.defaultValue)})${this.getTagString()}`;
     }
     getPropertyConverterFn() {
         return 'convertVector';
@@ -451,7 +463,8 @@ class Vector3 extends BaseType {
         this.defaultValue = [ x||0, y||0, z||0 ];
     }
     getTraitlet() {
-        return `Vector3(default_value=${JSON.stringify(this.defaultValue)})${this.getTagString()}`;
+        return `Vector3(default_value=${
+            JSON.stringify(this.defaultValue)})${this.getTagString()}`;
     }
     getPropertyConverterFn() {
         return 'convertVector';
@@ -467,7 +480,8 @@ class Vector4 extends BaseType {
         this.defaultValue = [ x||0, y||0, z||0, w||0 ];
     }
     getTraitlet() {
-        return `Vector4(default_value=${JSON.stringify(this.defaultValue)})${this.getTagString()}`;
+        return `Vector4(default_value=${
+            JSON.stringify(this.defaultValue)})${this.getTagString()}`;
     }
     getPropertyConverterFn() {
         return 'convertVector';
@@ -519,7 +533,8 @@ class Matrix3 extends BaseType {
         ];
     }
     getTraitlet() {
-        return `Matrix3(default_value=${JSON.stringify(this.defaultValue)})${this.getTagString()}`;
+        return `Matrix3(default_value=${
+            JSON.stringify(this.defaultValue)})${this.getTagString()}`;
     }
     getPropertyConverterFn() {
         return 'convertMatrix';
@@ -540,7 +555,8 @@ class Matrix4 extends BaseType {
         ];
     }
     getTraitlet() {
-        return `Matrix4(default_value=${JSON.stringify(this.defaultValue)})${this.getTagString()}`;
+        return `Matrix4(default_value=${
+            JSON.stringify(this.defaultValue)})${this.getTagString()}`;
     }
     getPropertyConverterFn() {
         return 'convertMatrix';
@@ -558,7 +574,8 @@ class Euler extends BaseType {
     }
 
     getTraitlet() {
-        return `Euler(default_value=${JSON.stringify(this.defaultValue)})${this.getTagString()}`;
+        return `Euler(default_value=${
+            JSON.stringify(this.defaultValue)})${this.getTagString()}`;
     }
     getPropertyConverterFn() {
         return 'convertEuler';

--- a/js/scripts/prop-types.js
+++ b/js/scripts/prop-types.js
@@ -224,7 +224,7 @@ class BufferMorphAttributes extends BaseType {
         const instances = typeNames.map(function(typeName) {
             return `        Instance(${typeName})`;
         });
-        return 'Dict(Tuple(Union([\n' + instances.join(',\n') + '\n    ])))' + this.getTagString();
+        return 'Dict(TypedTuple(Union([\n' + instances.join(',\n') + '\n    ])))' + this.getTagString();
     }
     getPropArrayName() {
         return 'three_nested_properties';
@@ -499,7 +499,7 @@ class FaceArray extends BaseType {
         this.defaultValue = [];
     }
     getTraitlet() {
-        return `Tuple(trait=Face3())${this.getTagString()}`;
+        return `TypedTuple(trait=Face3())${this.getTagString()}`;
     }
     getPropertyConverterFn() {
         return 'convertFaceArray';

--- a/js/scripts/templates/py_wrapper.mustache
+++ b/js/scripts/templates/py_wrapper.mustache
@@ -1,9 +1,12 @@
 import six
-from ipywidgets import Widget, DOMWidget, widget_serialization, Color, register
+from ipywidgets import (
+    Widget, DOMWidget, widget_serialization, Color, register
+)
+from ipywidgets.widgets.trait_types import TypedTuple
 from traitlets import (
     Unicode, Int, CInt, Instance, ForwardDeclaredInstance, This, Enum,
     Tuple, List, Dict, Float, CFloat, Bool, Union, Any,
-    )
+)
 
 from {{ py_base_relative_path }}_base.Three import ThreeWidget
 from {{ py_base_relative_path }}enums import *


### PR DESCRIPTION
- Use `TypedTuple` from ipywidgets, allowing for variable length, while still performing type check.
- Lint some long lines.

Closes #212.