### PR TITLE
Correctly generate infinity defaults in JS

### DIFF
--- a/js/scripts/prop-types.js
+++ b/js/scripts/prop-types.js
@@ -9,6 +9,9 @@ class BaseType {
         this.nullable = options.nullable === true;
     }
     getJSPropertyValue() {
+        if (this.defaultValue === Infinity || this.defaultValue === -Infinity) {
+            return this.defaultValue.toString();
+        }
         return JSON.stringify(this.defaultValue);
     }
     getPropArrayName() {


### PR DESCRIPTION
Previously, the defaults for autogenerated JS that are +/-Infinity would be incorrectly emitted as null.

Fixes #215.