### PR TITLE
Fix listen to datawidget

### DIFF
--- a/js/src/_base/Three.js
+++ b/js/src/_base/Three.js
@@ -186,7 +186,7 @@ var ThreeModel = widgets.WidgetModel.extend({
 
         // Handle changes in data widgets/union properties
         this.datawidget_properties.forEach(function(propName) {
-            dataserializers.listenToUnion(this, propName, this.onChildChanged.bind(this), false);
+            dataserializers.listenToUnion(this, propName, this.onDataChanged.bind(this), false);
         }, this);
 
         this.on('change', this.onChange, this);
@@ -345,6 +345,16 @@ var ThreeModel = widgets.WidgetModel.extend({
 
     onChildChanged: function(model) {
         console.debug('child changed: ' + model.model_id);
+        // Propagate up hierarchy:
+        this.trigger('childchange', this);
+    },
+
+    onDataChanged: function(model, options) {
+        console.debug('child data changed: ' + model.model_id);
+        // Treat a data widget change as if data attribute changed
+        // Note: hasChanged() etc won't identify the attribute, so
+        // property_mappers should be used for union properties.
+        this.onChange(model, options);
         // Propagate up hierarchy:
         this.trigger('childchange', this);
     },


### PR DESCRIPTION
Add a special change callback for when the data in a data widget change. This will not trigger the normal change notifier, which would normally push this to the three object. Note that since this attribute will not be be marked in `hasChange()`. For this reason, either property mapper should be used, or this callback should call `syncToThreeObj` with `force=true`. For now, we rely on mappers.