### PR TITLE
Update pythreejs.py to silence traitlets warning

### DIFF
--- a/pythreejs/pythreejs.py
+++ b/pythreejs/pythreejs.py
@@ -53,7 +53,7 @@ class SurfaceGeometry(BufferGeometry):
     """
     A regular grid with heights
     """
-    z = List(CFloat, [0] * 100)
+    z = List(CFloat(), [0] * 100)
     width = CInt(10)
     height = CInt(10)
     width_segments = CInt(10, read_only=True)


### PR DESCRIPTION
Here's a one line fix to silence a traitlets deprecation warning in pythreejs.py

Similar to issue https://github.com/jupyter-widgets/pythreejs/issues/236

Traitlets warning encountered:
```
...\site-packages\pythreejs\pythreejs.py:56
  C:\Users\genevieb\AppData\Local\conda\conda\envs\ipyvolume-dev\lib\site-packages\pythreejs\pythreejs.py:56: DeprecationWarning: Traits should be given as instances, not types (for example, `Int()`, not `Int`). Passing types is deprecated in traitlets 4.1.
    z = List(CFloat, [0] * 100)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```