### PR TITLE
Update traits.py for collections deprecation warning

### DIFF
--- a/pythreejs/traits.py
+++ b/pythreejs/traits.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from collections import namedtuple, Sequence
+from collections import namedtuple
+try:
+    from collections.abc import Sequence  # python3
+except ImportError:
+    from collections import Sequence  # python2
 import six
 import re
 import warnings


### PR DESCRIPTION
Silence deprecation warning from collections.

```
\site-packages\pythreejs\traits.py:4
  C:\Users\genevieb\AppData\Local\conda\conda\envs\ipyvolume-dev\lib\site-packages\pythreejs\traits.py:4: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import namedtuple, Sequence
```