### PR TITLE
Lazy-load widgets in jupyterlab

### DIFF
--- a/js/src/jupyterlab-plugin.js
+++ b/js/src/jupyterlab-plugin.js
@@ -1,6 +1,5 @@
-var jupyter_threejs = require('./index');
-
 var base = require('@jupyter-widgets/base');
+var version = require('./version');
 
 module.exports = {
     id: 'jupyter.extensions.jupyter-threejs',
@@ -8,8 +7,22 @@ module.exports = {
     activate: function(app, widgets) {
         widgets.registerWidget({
             name: 'jupyter-threejs',
-            version: jupyter_threejs.version,
-            exports: jupyter_threejs
+            version: version.version,
+            exports: function(){
+                return new Promise(function(resolve, reject){
+                    require.ensure(
+                        ['./index'],
+                        function(require) {
+                            resolve(require('./index'));
+                        },
+                        function(err) {
+                            console.error(err);
+                            reject(err);
+                        },
+                        'jupyter-threejs'
+                    );
+                });
+            }
         });
     },
     autoStart: true


### PR DESCRIPTION
This lazy-loads the main widgets (and therefore THREE) in lab with [require.ensure](https://webpack.js.org/api/module-methods/#requireensure). This cuts ~6mb off a dev `vendors~main`, and 1.1mb off a prod one, ignoring the sourcemap changes. 