### PR TITLE
DOC: Remove jupyter_sphinx

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,4 +11,3 @@ dependencies:
 - scikit-image
 - sphinx
 - nbsphinx
-- jupyter_sphinx

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,6 @@ extensions = [
     'sphinx.ext.todo',
     'autodoc_traits',
     'nbsphinx',
-    'jupyter_sphinx.embed_widgets',
     'nbsphinx_link',
 ]
 
@@ -207,8 +206,6 @@ def setup(app):
             check_call(['npm', 'run', 'build:bundles-prod'])
         finally:
             os.chdir(popd)
-
-    app.setup_extension('jupyter_sphinx.embed_widgets')
 
     def add_scripts(app):
         for fname in ['jupyter-threejs.js']:

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ setup_args = {
         'docs': [
             'sphinx>=1.5',
             'nbsphinx>=0.2.13',
-            'jupyter_sphinx',
             'nbsphinx-link',
         ]
     },


### PR DESCRIPTION
This is not necessary anymore since `nbsphinx` automatically supports widgets (see https://github.com/spatialaudio/nbsphinx/pull/345).

Closes #275.