### PR TITLE
Travis-CI: Change YAML escaping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ before_install:
 install:
   - pip install --upgrade -e ".[test, examples, docs]"
 script:
-  - if [[ $GROUP == python ]]; then
+  - |
+    if [[ $GROUP == python ]]; then
       py.test -l --nbval-lax --current-env examples;
     elif [[ $GROUP == docs ]]; then
       EXIT_STATUS=0


### PR DESCRIPTION
As speculated in https://github.com/jupyter-widgets/pythreejs/pull/307#issuecomment-569780225, it turns out that the `GROUP=docs` tests have never been running on Travis-CI.

And they are of course totally not passing.