### PR TITLE
add github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
   PYTHONUNBUFFERED: 1
   PYTHONIOENCODING: utf-8
+  CACHE_EPOCH: 0
 
 defaults:
   run:
@@ -30,6 +31,16 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node: 14.x
+    - name: Cache pip packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: |
+          ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-build-${{ hashFiles('setup.py', 'pyproject.toml') }}
+        restore-keys: |
+          ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-build-
+          ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-build-
+    - name: Cache npm packages
     - name: Install installation dependencies
       run: |
         set -eux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install package and docs dependencies
         run: |
           set -eux
-          pip install -vv -U .[docs,examples,test] requests_cache 'traitlets==4.*'
+          pip install -vv -U -e .[docs,examples,test] requests_cache 'traitlets==4.*'
       - name: Build docs
         run: |
           set -eux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,13 @@ jobs:
         with:
           node-version: 14.x
       - name: Install package and docs dependencies
+        # run: |
+        #  set -eux
+        #  pip install -vv -U .[docs,examples,test] requests_cache 'traitlets==4.*'
+        # TODO: uncomment above, remove below to get docs to build, add link to issue
         run: |
           set -eux
-          pip install -vv -U .[docs,examples,test] requests_cache 'traitlets==4.*'
+          pip install -vv -U .[docs,examples,test] requests_cache
       - name: Build docs
         run: |
           set -eux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up node
       uses: actions/setup-node@v2
       with:
-        node: 14.x
+        node-version: 14.x
     - name: Cache pip packages
       uses: actions/cache@v1
       with:
@@ -90,7 +90,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node: 14.x
+          node-version: 14.x
       - name: Install package and docs dependencies
         run: |
           set -eux
@@ -156,7 +156,7 @@ jobs:
       name: Set up node
       uses: actions/setup-node@v2
       with:
-        node: ${{ matrix.node }}
+        node-version: ${{ matrix.node }}
     - name: Download distributions
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,18 +112,21 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: [3.6, 3.8, 3.9]
+        python: [3.6, 3.7, 3.8, 3.9]
         include:
           - python: 3.6
             dist: 'pythreejs*.tar.gz'
-          - python: 3.8
+          - python: 3.7
             dist: 'pythreejs*.whl'
             lab: 1
             node: 10
-          - python: 3.9
+          - python: 3.8
             dist: 'pythreejs*.whl'
             lab: 2
             node: 14
+          - python: 3.9
+            dist: 'pythreejs*.whl'
+            lab: 3
           - os: windows
             py_cmd: python
           - os: macos
@@ -191,8 +194,6 @@ jobs:
       run: |
         set -eux
         jupyter labextension install --no-build --debug ./dist/*.tgz @jupyter-widgets/jupyterlab-manager
-        jupyter labextension list
-        jupyter labextension list 2>&1 | grep -ie "jupyter-threejs" -
     - if: ${{ matrix.node }}
       name: Build lab
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install package and docs dependencies
         run: |
           set -eux
-          pip install -vv -U -e .[docs,examples,test] requests_cache 'traitlets==4.*'
+          pip install -vv -U .[docs,examples,test] requests_cache 'traitlets==4.*'
       - name: Build docs
         run: |
           set -eux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
           ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-build-${{ hashFiles('setup.py', 'pyproject.toml') }}
         restore-keys: |
           ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-build-
-          ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-build-
-    - name: Cache npm packages
     - name: Install installation dependencies
       run: |
         set -eux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,198 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: '*'
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
+  PYTHONUNBUFFERED: 1
+  PYTHONIOENCODING: utf-8
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Set up Node
+      uses: actions/setup-node@v2
+      with:
+        node: 14.x
+    - name: Install packaging dependencies
+      run: |
+        set -eux
+        python -m pip install -vv -U --user pip wheel setuptools
+        yarn --version || npm install -g yarn
+    - name: Pre-install node dependencies
+      run: |
+        set -eux
+        cd js
+        yarn --ignore-optional
+    - name: Build sdist
+      run: python setup.py sdist
+    - name: Build wheel
+      run: python setup.py bdist_wheel
+    - name: Collect and hash distributions
+      run: |
+        set -eux
+        cp js/lab-dist/jupyter-threejs-*.tgz dist
+        cd dist
+        sha256sum * | tee SHA256SUMS
+    - name: Upload distributions
+      uses: actions/upload-artifact@v2
+      with:
+        name: dist ${{ github.run_number }}
+        path: ./dist
+
+  docs:
+    name: docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install apt dependencies
+        run: |
+          set -eux
+          sudo apt install pandoc
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install packaging dependencies
+        run: |
+          set -eux
+          python -m pip install -vv -U --user pip wheel setuptools
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node: 14.x
+      - name: Install package and docs dependencies
+        run: |
+          set -eux
+          pip install -vv -U .[docs,examples,test] requests_cache 'traitlets==4.*'
+      - name: Build docs
+        run: |
+          set -eux
+          cd docs
+          make html
+      - name: Upload docs
+        uses: actions/upload-artifact@v2
+        with:
+          name: docs ${{ github.run_number }}
+          path: ./docs/build
+      - name: Cache links
+        uses: actions/cache@v1
+        with:
+          path: ./build/links
+          key: ${{ runner.os }}-links
+      - name: Check links
+        run: |
+          set -eux
+          mkdir -p build/links/cache
+          cd docs
+          pytest-check-links --check-links-cache --check-links-cache-name ../build/links/cache
+
+  test:
+    name: test ${{ matrix.os }}${{ matrix.python }} ${{ matrix.node }} ${{ matrix.lab }}
+    needs: [build]
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos, windows]
+        python: [3.6, 3.8, 3.9]
+        include:
+          - python: 3.6
+            dist: 'pythreejs*.tar.gz'
+          - python: 3.8
+            dist: 'pythreejs*.whl'
+            lab: 1
+            node: 10
+          - python: 3.9
+            dist: 'pythreejs*.whl'
+            lab: 2
+            node: 14
+          - os: windows
+            py_cmd: python
+          - os: macos
+            py_cmd: python3
+          - os: ubuntu
+            py_cmd: python
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - uses: actions/download-artifact@v2
+      with:
+        name: dist ${{ github.run_number }}
+        path: ./dist
+    - name: Install installation dependencies
+      run: |
+        set -eux
+        ${{ matrix.py_cmd }} -m pip install -vv --user -U pip wheel setuptools
+    - name: Install package (maybe lab)
+      run: |
+        set -eux
+        cd dist
+        ${{ matrix.py_cmd }} -m pip install -vv ${{ matrix.dist }}
+    - name: Validate environment
+      run: |
+        set -eux
+        ${{ matrix.py_cmd }} -m pip freeze
+        ${{ matrix.py_cmd }} -m pip check
+    - if: ${{ matrix.lab }}
+      name: Install lab
+      run: |
+        set -eux
+        ${{ matrix.py_cmd }} -m pip install -vv 'jupyterlab==${{ matrix.lab }}.*'
+    - name: Install test dependencies
+      # explicit file installs don't support extras, skimage brings most along
+      run: |
+        set -eux
+        ${{ matrix.py_cmd }} -m pip install -vv nbval scikit-image ipywebrtc
+    - name: Run python tests
+      # remove the source directory to avoid surprises
+      run: |
+        set -eux
+        rm -rf pythreejs
+        ${{ matrix.py_cmd }} -m pytest -vv -l --nbval-lax --current-env .
+    - name: Check nbextension
+      run: |
+        set -eux
+        jupyter nbextension list
+        jupyter nbextension list 2>&1 | grep -ie "jupyter-threejs/extension.*enabled" -
+    - if: ${{ matrix.node }}
+      name: Set up Node
+      uses: actions/setup-node@v2
+      with:
+        node: ${{ matrix.node }}
+    - if: ${{ matrix.node }}
+      name: Install labextension
+      run: |
+        set -eux
+        jupyter labextension install --no-build --debug ./dist/*.tgz @jupyter-widgets/jupyterlab-manager
+        jupyter labextension list
+        jupyter labextension list 2>&1 | grep -ie "jupyter-threejs" -
+    - if: ${{ matrix.node }}
+      name: Build lab
+      run: |
+        set -eux
+        jupyter lab build --debug
+    - if: ${{ matrix.lab }}
+      name: Check labextension
+      run: |
+        set -eux
+        jupyter labextension list
+        jupyter labextension list 2>&1 | grep -ie "jupyter-threejs.*enabled.*ok" -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,13 +92,14 @@ jobs:
         with:
           node-version: 14.x
       - name: Install package and docs dependencies
-        # run: |
-        #  set -eux
-        #  pip install -vv -U .[docs,examples,test] requests_cache 'traitlets==4.*'
-        # TODO: uncomment above, remove below to get docs to build, add link to issue
         run: |
           set -eux
-          pip install -vv -U .[docs,examples,test] requests_cache
+          pip install -vv -U -e .[docs,examples,test] requests_cache
+      - name: Validate docs environment
+        run: |
+          set -eux
+          pip freeze
+          pip check
       - name: Build docs
         run: |
           set -eux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,15 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node: 14.x
+    - name: Install installation dependencies
+      run: |
+        set -eux
+        python -m pip install -vv -U --user pip wheel setuptools
+        yarn --version || npm install -g yarn
     - name: Install packaging dependencies
       run: |
         set -eux
-        python -m pip install -vv -U --user pip wheel setuptools 'jupyterlab~=3.0'
-        yarn --version || npm install -g yarn
+        python -m pip install -vv 'jupyterlab~=3.0'
     - name: Pre-install node dependencies
       run: |
         set -eux
@@ -70,7 +74,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Install packaging dependencies
+      - name: Install installation dependencies
         run: |
           set -eux
           python -m pip install -vv -U --user pip wheel setuptools
@@ -153,7 +157,7 @@ jobs:
       run: |
         set -eux
         ${{ matrix.py_cmd }} -m pip install -vv --user -U pip wheel setuptools
-    - name: Install package (maybe lab)
+    - name: Install package
       run: |
         set -eux
         cd dist
@@ -164,7 +168,7 @@ jobs:
         ${{ matrix.py_cmd }} -m pip freeze
         ${{ matrix.py_cmd }} -m pip check
     - if: ${{ matrix.lab }}
-      name: Install lab
+      name: Install JupyterLab
       run: |
         set -eux
         ${{ matrix.py_cmd }} -m pip install -vv 'jupyterlab==${{ matrix.lab }}.*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,13 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
+    - name: Check out
+      uses: actions/checkout@v2
+    - name: Set up python
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
-    - name: Set up Node
+    - name: Set up node
       uses: actions/setup-node@v2
       with:
         node: 14.x
@@ -59,12 +60,13 @@ jobs:
     name: docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out
+        uses: actions/checkout@v2
       - name: Install apt dependencies
         run: |
           set -eux
           sudo apt install pandoc
-      - name: Set up Python
+      - name: Set up python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
@@ -72,7 +74,7 @@ jobs:
         run: |
           set -eux
           python -m pip install -vv -U --user pip wheel setuptools
-      - name: Set up Node
+      - name: Set up node
         uses: actions/setup-node@v2
         with:
           node: 14.x
@@ -129,12 +131,19 @@ jobs:
           - os: ubuntu
             py_cmd: python
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
+    - name: Check out
+      uses: actions/checkout@v2
+    - name: Set up python
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
-    - uses: actions/download-artifact@v2
+    - if: ${{ matrix.node }}
+      name: Set up node
+      uses: actions/setup-node@v2
+      with:
+        node: ${{ matrix.node }}
+    - name: Download distributions
+      uses: actions/download-artifact@v2
       with:
         name: dist ${{ github.run_number }}
         path: ./dist
@@ -161,25 +170,24 @@ jobs:
       # explicit file installs don't support extras, skimage brings most along
       run: |
         set -eux
-        ${{ matrix.py_cmd }} -m pip install -vv nbval scikit-image ipywebrtc
+        ${{ matrix.py_cmd }} -m pip install -vv nbval scikit-image ipywebrtc pytest-cov codecov
     - name: Run python tests
       # remove the source directory to avoid surprises
       run: |
         set -eux
         rm -rf pythreejs
-        ${{ matrix.py_cmd }} -m pytest -vv -l --nbval-lax --current-env .
-    - name: Check nbextension
+        ${{ matrix.py_cmd }} -m pytest -vv -l --nbval-lax --current-env . --cov pythreejs --cov-report term-missing:skip-covered --no-cov-on-fail
+    - name: Upload coverage
+      run: |
+        set -eux
+        codecov
+    - name: Check notebook extension
       run: |
         set -eux
         jupyter nbextension list
         jupyter nbextension list 2>&1 | grep -ie "jupyter-threejs/extension.*enabled" -
     - if: ${{ matrix.node }}
-      name: Set up Node
-      uses: actions/setup-node@v2
-      with:
-        node: ${{ matrix.node }}
-    - if: ${{ matrix.node }}
-      name: Install labextension
+      name: Install lab extension
       run: |
         set -eux
         jupyter labextension install --no-build --debug ./dist/*.tgz @jupyter-widgets/jupyterlab-manager
@@ -191,7 +199,7 @@ jobs:
         set -eux
         jupyter lab build --debug
     - if: ${{ matrix.lab }}
-      name: Check labextension
+      name: Check lab extension
       run: |
         set -eux
         jupyter labextension list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install packaging dependencies
         run: |
           set -eux
-          python -m pip install -vv -U --user pip wheel setuptools
+          python -m pip install -vv -U --user pip wheel setuptools 'jupyterlab~=3.0'
       - name: Set up node
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install packaging dependencies
       run: |
         set -eux
-        python -m pip install -vv -U --user pip wheel setuptools
+        python -m pip install -vv -U --user pip wheel setuptools 'jupyterlab~=3.0'
         yarn --version || npm install -g yarn
     - name: Pre-install node dependencies
       run: |
@@ -73,7 +73,7 @@ jobs:
       - name: Install packaging dependencies
         run: |
           set -eux
-          python -m pip install -vv -U --user pip wheel setuptools 'jupyterlab~=3.0'
+          python -m pip install -vv -U --user pip wheel setuptools
       - name: Set up node
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,11 +105,20 @@ jobs:
         with:
           name: docs ${{ github.run_number }}
           path: ./docs/build
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=year::$(date +'%Y')"
+          echo "::set-output name=week::$(date +'%U')"
       - name: Cache links
         uses: actions/cache@v1
         with:
           path: ./build/links
-          key: ${{ runner.os }}-links
+          key: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-links-${{ steps.date.outputs.year }}-${{ steps.date.outputs.week }}
+          restore-keys: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-links-${{ steps.date.outputs.year }}-
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-links-
       - name: Check links
         run: |
           set -eux

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ docs/source/examples/img
 
 js/lab-dist
 js/package-lock.json
+pythreejs/labextension

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,8 @@ extensions = [
 # Ensure our extension is available:
 import sys
 from os.path import dirname, join as pjoin
+from sphinx.util import logging
+logger = logging.getLogger(__name__)
 docs = dirname(dirname(__file__))
 root = dirname(docs)
 sys.path.insert(0, root)
@@ -210,7 +212,7 @@ def setup(app):
     def add_scripts(app):
         for fname in ['jupyter-threejs.js']:
             if not os.path.exists(os.path.join(here, '_static', fname)):
-                app.warn('missing javascript file: %s' % fname)
+                logger.warn('missing javascript file: %s' % fname)
             app.add_javascript(fname)
 
     def add_images(app):

--- a/js/scripts/templates/py_enums.mustache
+++ b/js/scripts/templates/py_enums.mustache
@@ -15,6 +15,9 @@ class EnumNamespace:
     def __contains__(self, key):
         return key in self.__dict__
 
+    def __iter__(self):
+        yield from filter(lambda e: not e.startswith('_'), dir(self))
+
     def __repr__(self):
         return str(list(filter(lambda e: not e.startswith('_'), dir(self))))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 requires = ["jupyterlab~=3.0", "setuptools>=40.8.0", "wheel"]
-build-backend = "setuptools.build_meta"
+build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,2 @@
 [build-system]
 requires = ["jupyterlab~=3.0", "setuptools>=40.8.0", "wheel"]
-build-backend = "setuptools.build_meta:__legacy__"

--- a/pythreejs/_version.py
+++ b/pythreejs/_version.py
@@ -1,4 +1,4 @@
-version_info = (2, 2, 1, 'final')
+version_info = (2, 2, 2, 'dev')
 
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': '', 'dev': 'dev'}
 

--- a/pythreejs/enums.py
+++ b/pythreejs/enums.py
@@ -15,6 +15,9 @@ class EnumNamespace:
     def __contains__(self, key):
         return key in self.__dict__
 
+    def __iter__(self):
+        yield from filter(lambda e: not e.startswith('_'), dir(self))
+
     def __repr__(self):
         return str(list(filter(lambda e: not e.startswith('_'), dir(self))))
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,15 @@
 # -*- coding: utf-8 -*-
 from pathlib import Path
 
+HERE = Path(__file__).parent.resolve()
+
+try:
+    import setupbase
+except:
+    import sys
+    import os
+    sys.path += [str(HERE)]
+
 from setupbase import (
     log,
     create_cmdclass,
@@ -14,7 +23,6 @@ import setuptools
 
 LONG_DESCRIPTION = 'A Python/ThreeJS bridge utilizing the Jupyter widget infrastructure.'
 
-HERE = Path(__file__).parent.resolve()
 name = 'pythreejs'
 py_path = (HERE / name)
 js_path = (HERE / "js")

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,7 @@ from pathlib import Path
 
 HERE = Path(__file__).parent.resolve()
 
-try:
-    import setupbase
-except:
-    import sys
-    import os
-    sys.path += [str(HERE)]
+import setupbase
 
 from setupbase import (
     log,


### PR DESCRIPTION
This adds a GitHub Actions CI, derived from a number of other ones in the community. This is a single workflow, with one _tiny_ change to `conf.py` to avoid a long-deprecated API. I figure we can remove the travis job separately, maybe try to get RTD back up and running (might need to request the mamba feature flag).

I'm working directly off my `master` branch, where you can see my [Many Commits of Shame](https://github.com/bollwyvl/pythreejs/actions?query=workflow%3ACI+branch%3Amaster) with the occasional :heavy_check_mark: 

Overview:
- linux build job
  - uploads distribution artifacts
- linux docs job
  - uploads docs artifacts
  - checks all links
    - :new: uses a link cache, expires every week
- matrix test job (3 os x 4 pythons x 3 labs x 2 LTS nodejs)
  - downloads the distribution artifacts
  - runs nbval tests against one of them, depending on the python version
  - :new: coverage
  - :new: all excursions checks that the nbextension is packaged 
  - :new: excursions with jupyterlab check that the labextension is packaged

## Possible Follow-on
- remove travis
- README badges
- not building the js stuff twice for sdist, wheel
- linting/formatting (for non-generated code, only, maybe)
- look into coverage misses, add some thresholds
- add some more test stuff to `extras`
- update sphinx plugin for traitlets 5 (super cool!), maybe spin off as separate package
- better caching: having `requirements.txt`, `yarn.lock`, etc. would be needed to drive entropy