### PR TITLE
Extend Picker to pick individual Points objects.

### DIFF
--- a/js/scripts/three-class-config.js
+++ b/js/scripts/three-class-config.js
@@ -266,6 +266,14 @@ module.exports = {
             event: new Types.String('click', {
                 help: 'The DOM MouseEvent type to trigger the pick',
             }),
+            lineThreshold: new Types.Float(1.0, {
+                nullable: false,
+                help: 'The threshold value for line picking',
+            }),
+            pointThreshold: new Types.Float(1.0, {
+                nullable: false,
+                help: 'The threshold value for point picking',
+            }),
             all: new Types.Bool(false, {
                 help: 'Wether to send info on all object intersections beneath the picked point, or only the first one. See ``picked``.',
             }),
@@ -276,6 +284,10 @@ module.exports = {
             point: new Types.Vector3(0, 0, 0, {
                 help: 'The coordinates of the picked point (all zero if no object picked)',
             }),
+            instanceId: new Types.Int(null, {
+                nullable: true,
+                help: 'The InstanceID if picking a multi-instanced object',
+            }),
             face: new Types.Vector3(0, 0, 0, {
                 help: 'The vertex indices of the picked face (all zero if no face picked)',
             }),
@@ -284,6 +296,10 @@ module.exports = {
             }),
             faceVertices: new Types.VectorArray({
                 help: 'The three vertices that make up the picked face, as vectors (empty if no face picked)',
+            }),
+            index: new Types.Int(null, {
+                nullable: true,
+                help: 'The index of a picked Points instance',
             }),
             faceIndex: new Types.Int(null, {
                 nullable: true,
@@ -310,7 +326,8 @@ module.exports = {
         },
         propsDefinedByThree: [
             'distance', 'point', 'face', 'faceNormal', 'faceVertices',
-            'faceIndex', 'object', 'picked', 'uv', 'indices'],
+            'faceIndex', 'object', 'picked', 'uv', 'indices', 'instanceId',
+            'index'],
         constructorArgs: ['controlling'],
     },
 

--- a/js/src/controls/Picker.js
+++ b/js/src/controls/Picker.js
@@ -35,7 +35,9 @@ var PickerModel = PickerAutogen.PickerModel.extend({
 
     onPick: function() {
         var mouse = this.obj.pickCoordinates;
-        var objects = pick(mouse, this.camera, this.get('controlling').obj);
+        var objects = pick(mouse, this.camera, this.get('controlling').obj,
+            this.get('lineThreshold'), this.get('pointThreshold')
+        );
 
         var info = getinfo(objects.length > 0 ? objects[0] : null);
 
@@ -102,8 +104,12 @@ PickerControls.prototype = Object.create( THREE.EventDispatcher.prototype );
 PickerControls.prototype.constructor = PickerControls;
 
 
-function pick(mouse, camera, root) {
+function pick(mouse, camera, root, lineThreshold, pointThreshold) {
     var raycaster = new THREE.Raycaster();
+    raycaster.params = {
+        'Points': { 'threshold': pointThreshold },
+        'Line': { 'threshold': lineThreshold }
+    };
     raycaster.setFromCamera( mouse, camera );
     return raycaster.intersectObject(root, true);
 }
@@ -134,6 +140,8 @@ function getinfo(o) {
             faceIndex: o.faceIndex !== undefined && o.faceIndex !== null ? o.faceIndex : null,
             object: o.object.ipymodel,
             uv: o.uv ? [o.uv.x, o.uv.y] : [0, 0],
+            instanceId: o.instanceId !== undefined ? o.instanceId : null,
+            index: o.index !== undefined ? o.index : null,
         };
     }
     return {
@@ -146,6 +154,8 @@ function getinfo(o) {
         faceIndex: null,
         object: null,
         uv: [0, 0],
+        instanceId: null,
+        index: null,
     };
 }
 


### PR DESCRIPTION
This adds on parameters to the `Picker` object so that the pick-threshold for points and lines can be adjusted, and so that it will return the `instanceId` of an instanced mesh as well as the `index` when picking on a `Points` object.  This enables the `Picker` object to work with `Points` and `PointClouds`, where it returns the index into a `BufferGeometry` corresponding to the picked (sub)instance.

I believe this is relevant to #333, as it should enable indexing into a `BufferGeometry` and the corresponding attributes to retrieve the color (or other attributes of the source array).
